### PR TITLE
Use chordfree endpoint instead of tmpl file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ repository = "https://github.com/shahinrostami/chord_rs"
 
 [dependencies]
 ureq = {version = "0.11.4", features = ["json"]}
-nanoid = "0.3.0"

--- a/src/divided_chord.rs
+++ b/src/divided_chord.rs
@@ -1,25 +1,27 @@
 mod lib;
 use lib::{Chord, Plot};
+use nanoid::nanoid;
 use std::fs;
 use std::io::prelude::*;
-use nanoid::nanoid;
 
 fn main() {
     let matrix: Vec<Vec<f64>> = vec![
-    vec![0.0, 0.0, 0.0, 1.0, 4.0, 1.0],
-    vec![0.0, 0.0, 0.0, 1.0, 3.0, 2.0],
-    vec![0.0, 0.0, 0.0, 1.0, 2.0, 2.0],
-    vec![1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
-    vec![4.0, 3.0, 2.0, 0.0, 0.0, 0.0],
-    vec![1.0, 2.0, 2.0, 0.0, 0.0, 0.0],
+        vec![0.0, 0.0, 0.0, 1.0, 4.0, 1.0],
+        vec![0.0, 0.0, 0.0, 1.0, 3.0, 2.0],
+        vec![0.0, 0.0, 0.0, 1.0, 2.0, 2.0],
+        vec![1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+        vec![4.0, 3.0, 2.0, 0.0, 0.0, 0.0],
+        vec![1.0, 2.0, 2.0, 0.0, 0.0, 0.0],
     ];
 
     let names: Vec<String> = vec!["A", "B", "C", "1", "2", "3"]
-    .into_iter()
-    .map(String::from)
-    .collect();
+        .into_iter()
+        .map(String::from)
+        .collect();
 
-    let colors: Vec<String> = vec!["#7400B8", "#5E60CE", "#5684D6", "#56CFE1", "#64DFDF", "#80FFDB"]
+    let colors: Vec<String> = vec![
+        "#7400B8", "#5E60CE", "#5684D6", "#56CFE1", "#64DFDF", "#80FFDB",
+    ]
     .into_iter()
     .map(String::from)
     .collect();
@@ -29,7 +31,7 @@ fn main() {
         key: String::from("enter license key here"),
         matrix: matrix.clone(),
         names: names.clone(),
-        colors: colors,
+        colors,
         divide: true,
         divide_idx: 3,
         ..lib::Chord::default()

--- a/src/divided_chord.rs
+++ b/src/divided_chord.rs
@@ -1,6 +1,5 @@
 mod lib;
 use lib::{Chord, Plot};
-use nanoid::nanoid;
 use std::fs;
 use std::io::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use nanoid::nanoid;
 use std::fs;
 use std::io::prelude::*;
 use ureq::json;
@@ -38,138 +37,62 @@ pub struct Chord {
     pub instances: u64,
 }
 
-impl Plot for Chord {
-    fn show(&self) {
+impl Chord {
+    fn template_url(&self) -> &'static str {
         if self.user.is_empty() && self.key.is_empty() {
-            let template_url = "https://shahinrostami.com/assets/chord/chord_0_0_12.tmpl";
-            let mut res = ureq::get(template_url).call().into_string().unwrap();
-            res = res.replace("${tag_id}", &format!("chart-{}", nanoid!()));
-            res = res.replace("${matrix}", &format!("{:?}", self.matrix));
-            res = res.replace("${names}", &format!("{:?}", self.names));
-
-            if self.colors.len() == 1 {
-                res = res.replace("${colors}", &self.colors[0]);
-            } else {
-                res = res.replace("${colors}", &format!("{:?}", self.colors));
-            }
-
-            res = res.replace("${opacity}", &self.opacity.to_string());
-            res = res.replace("${padding}", &self.padding.to_string());
-            res = res.replace("${width}", &self.width.to_string());
-            res = res.replace("${label_color}", &self.label_color);
-            res = res.replace("${wrap_labels}", &self.wrap_labels.to_string());
-            res = res.replace("${margin}", &self.margin.to_string());
-            res = res.replace("${credit}", &self.credit.to_string());
-            res = res.replace("${font_size}", &self.font_size);
-            res = res.replace("${font_size_large}", &self.font_size_large);
-
-            println!("EVCXR_BEGIN_CONTENT text/html\n{}\nEVCXR_END_CONTENT", res);
+            "https://api.shahin.dev/chordfree"
         } else {
-            let template_url = "https://api.shahin.dev/chord";
-
-            let res = ureq::post(template_url)
-                .auth(&self.user.to_string(), &self.key.to_string())
-                .send_json(json!({
-                    "colors":self.colors,
-                    "opacity":self.opacity,
-                    "matrix":self.matrix,
-                    "names":self.names,
-                    "padding":self.padding,
-                    "width":self.width,
-                    "label_color":self.label_color,
-                    "wrap_labels":self.wrap_labels,
-                    "credit":self.credit,
-                    "margin":self.margin,
-                    "font_size":self.font_size,
-                    "font_size_large":self.font_size_large,
-                    "details":self.details,
-                    "details_thumbs":self.details_thumbs,
-                    "thumbs_font_size":self.thumbs_font_size,
-                    "thumbs_width":self.thumbs_width,
-                    "thumbs_margin":self.thumbs_margin,
-                    "popup_width":self.popup_width,
-                    "noun":self.noun,
-                    "details_separator":self.details_separator,
-                    "divide":self.divide,
-                    "divide_idx":self.divide_idx,
-                    "divide_size":self.divide_size,
-                    "instances":self.instances
-                }))
-                .into_string()
-                .unwrap();
-
-            println!("EVCXR_BEGIN_CONTENT text/html\n{}\nEVCXR_END_CONTENT", res);
+            "https://api.shahin.dev/chord"
         }
     }
 
+    fn render(&self) -> String {
+        ureq::post(self.template_url())
+            .auth(&self.user.to_string(), &self.key.to_string())
+            .send_json(json!({
+                "colors":self.colors,
+                "opacity":self.opacity,
+                "matrix":self.matrix,
+                "names":self.names,
+                "padding":self.padding,
+                "width":self.width,
+                "label_color":self.label_color,
+                "wrap_labels":self.wrap_labels,
+                "credit":self.credit,
+                "margin":self.margin,
+                "font_size":self.font_size,
+                "font_size_large":self.font_size_large,
+                "details":self.details,
+                "details_thumbs":self.details_thumbs,
+                "thumbs_font_size":self.thumbs_font_size,
+                "thumbs_width":self.thumbs_width,
+                "thumbs_margin":self.thumbs_margin,
+                "popup_width":self.popup_width,
+                "noun":self.noun,
+                "details_separator":self.details_separator,
+                "divide":self.divide,
+                "divide_idx":self.divide_idx,
+                "divide_size":self.divide_size,
+                "instances":self.instances
+            }))
+            .into_string()
+            .unwrap()
+    }
+}
+
+impl Plot for Chord {
+    fn show(&self) {
+        let html = self.render();
+        println!("EVCXR_BEGIN_CONTENT text/html\n{}\nEVCXR_END_CONTENT", html);
+    }
+
     fn to_html(&self) {
-        if self.user.is_empty() && self.key.is_empty() {
-            let template_url = "https://shahinrostami.com/assets/chord/chord_0_0_12.tmpl";
-            let mut res = ureq::get(template_url).call().into_string().unwrap();
-            res = res.replace("${tag_id}", &format!("chart-{}", nanoid!()));
-            res = res.replace("${matrix}", &format!("{:?}", self.matrix));
-            res = res.replace("${names}", &format!("{:?}", self.names));
+        let html = self.render();
+        let file_name = "out.html";
 
-            if self.colors.len() == 1 {
-                res = res.replace("${colors}", &self.colors[0]);
-            } else {
-                res = res.replace("${colors}", &format!("{:?}", self.colors));
-            }
-
-            res = res.replace("${opacity}", &self.opacity.to_string());
-            res = res.replace("${padding}", &self.padding.to_string());
-            res = res.replace("${width}", &self.width.to_string());
-            res = res.replace("${label_color}", &self.label_color);
-            res = res.replace("${wrap_labels}", &self.wrap_labels.to_string());
-            res = res.replace("${margin}", &self.margin.to_string());
-            res = res.replace("${credit}", &self.credit.to_string());
-            res = res.replace("${font_size}", &self.font_size);
-            res = res.replace("${font_size_large}", &self.font_size_large);
-            let file_name = "out.html";
-
-            let mut file = fs::File::create(file_name).unwrap();
-            file.write_all(res.as_bytes())
-                .expect("writing to output file failed");
-        } else {
-            let template_url = "https://api.shahin.dev/chord";
-
-            let res = ureq::post(template_url)
-                .auth(&self.user.to_string(), &self.key.to_string())
-                .send_json(json!({
-                    "colors":self.colors,
-                    "opacity":self.opacity,
-                    "matrix":self.matrix,
-                    "names":self.names,
-                    "padding":self.padding,
-                    "width":self.width,
-                    "label_color":self.label_color,
-                    "wrap_labels":self.wrap_labels,
-                    "credit":self.credit,
-                    "margin":self.margin,
-                    "font_size":self.font_size,
-                    "font_size_large":self.font_size_large,
-                    "details":self.details,
-                    "details_thumbs":self.details_thumbs,
-                    "thumbs_font_size":self.thumbs_font_size,
-                    "thumbs_width":self.thumbs_width,
-                    "thumbs_margin":self.thumbs_margin,
-                    "popup_width":self.popup_width,
-                    "noun":self.noun,
-                    "details_separator":self.details_separator,
-                    "divide":self.divide,
-                    "divide_idx":self.divide_idx,
-                    "divide_size":self.divide_size,
-                    "instances":self.instances
-                }))
-                .into_string()
-                .unwrap();
-
-            let file_name = "out.html";
-
-            let mut file = fs::File::create(file_name).unwrap();
-            file.write_all(res.as_bytes())
-                .expect("writing to output file failed");
-        }
+        let mut file = fs::File::create(file_name).unwrap();
+        file.write_all(html.as_bytes())
+            .expect("writing to output file failed");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
+use nanoid::nanoid;
 use std::fs;
 use std::io::prelude::*;
-use nanoid::nanoid;
 use ureq::json;
 
 pub trait Plot {
@@ -36,24 +36,20 @@ pub struct Chord {
     pub divide_idx: u64,
     pub divide_size: f64,
     pub instances: u64,
-    
-
-
 }
 
 impl Plot for Chord {
     fn show(&self) {
-        if(self.user.is_empty() && self.key.is_empty()){
+        if self.user.is_empty() && self.key.is_empty() {
             let template_url = "https://shahinrostami.com/assets/chord/chord_0_0_12.tmpl";
             let mut res = ureq::get(template_url).call().into_string().unwrap();
             res = res.replace("${tag_id}", &format!("chart-{}", nanoid!()));
             res = res.replace("${matrix}", &format!("{:?}", self.matrix));
             res = res.replace("${names}", &format!("{:?}", self.names));
 
-            if(self.colors.len() == 1){
-                res = res.replace("${colors}",&self.colors[0]);
-            }
-            else{
+            if self.colors.len() == 1 {
+                res = res.replace("${colors}", &self.colors[0]);
+            } else {
                 res = res.replace("${colors}", &format!("{:?}", self.colors));
             }
 
@@ -68,60 +64,58 @@ impl Plot for Chord {
             res = res.replace("${font_size_large}", &self.font_size_large);
 
             println!("EVCXR_BEGIN_CONTENT text/html\n{}\nEVCXR_END_CONTENT", res);
-        }
-        else{
+        } else {
             let template_url = "https://api.shahin.dev/chord";
-            
-            let mut res = ureq::post(template_url)
-            .auth(&self.user.to_string(),&self.key.to_string())
-            .send_json(json!({
-                "colors":self.colors,
-                "opacity":self.opacity,
-                "matrix":self.matrix,
-                "names":self.names,
-                "padding":self.padding,
-                "width":self.width,
-                "label_color":self.label_color,
-                "wrap_labels":self.wrap_labels,
-                "credit":self.credit,
-                "margin":self.margin,
-                "font_size":self.font_size,
-                "font_size_large":self.font_size_large,
-                "details":self.details,
-                "details_thumbs":self.details_thumbs,
-                "thumbs_font_size":self.thumbs_font_size,
-                "thumbs_width":self.thumbs_width,
-                "thumbs_margin":self.thumbs_margin,
-                "popup_width":self.popup_width,
-                "noun":self.noun,
-                "details_separator":self.details_separator,
-                "divide":self.divide,
-                "divide_idx":self.divide_idx,
-                "divide_size":self.divide_size,
-                "instances":self.instances
-            }))
-            .into_string().unwrap();
+
+            let res = ureq::post(template_url)
+                .auth(&self.user.to_string(), &self.key.to_string())
+                .send_json(json!({
+                    "colors":self.colors,
+                    "opacity":self.opacity,
+                    "matrix":self.matrix,
+                    "names":self.names,
+                    "padding":self.padding,
+                    "width":self.width,
+                    "label_color":self.label_color,
+                    "wrap_labels":self.wrap_labels,
+                    "credit":self.credit,
+                    "margin":self.margin,
+                    "font_size":self.font_size,
+                    "font_size_large":self.font_size_large,
+                    "details":self.details,
+                    "details_thumbs":self.details_thumbs,
+                    "thumbs_font_size":self.thumbs_font_size,
+                    "thumbs_width":self.thumbs_width,
+                    "thumbs_margin":self.thumbs_margin,
+                    "popup_width":self.popup_width,
+                    "noun":self.noun,
+                    "details_separator":self.details_separator,
+                    "divide":self.divide,
+                    "divide_idx":self.divide_idx,
+                    "divide_size":self.divide_size,
+                    "instances":self.instances
+                }))
+                .into_string()
+                .unwrap();
 
             println!("EVCXR_BEGIN_CONTENT text/html\n{}\nEVCXR_END_CONTENT", res);
-
         }
-    } 
+    }
 
     fn to_html(&self) {
-        if(self.user.is_empty() && self.key.is_empty()){
+        if self.user.is_empty() && self.key.is_empty() {
             let template_url = "https://shahinrostami.com/assets/chord/chord_0_0_12.tmpl";
             let mut res = ureq::get(template_url).call().into_string().unwrap();
             res = res.replace("${tag_id}", &format!("chart-{}", nanoid!()));
             res = res.replace("${matrix}", &format!("{:?}", self.matrix));
             res = res.replace("${names}", &format!("{:?}", self.names));
 
-            if(self.colors.len() == 1){
-                res = res.replace("${colors}",&self.colors[0]);
-            }
-            else{
+            if self.colors.len() == 1 {
+                res = res.replace("${colors}", &self.colors[0]);
+            } else {
                 res = res.replace("${colors}", &format!("{:?}", self.colors));
             }
-            
+
             res = res.replace("${opacity}", &self.opacity.to_string());
             res = res.replace("${padding}", &self.padding.to_string());
             res = res.replace("${width}", &self.width.to_string());
@@ -132,47 +126,49 @@ impl Plot for Chord {
             res = res.replace("${font_size}", &self.font_size);
             res = res.replace("${font_size_large}", &self.font_size_large);
             let file_name = "out.html";
-            
+
             let mut file = fs::File::create(file_name).unwrap();
-            file.write_all(res.as_bytes());
-        }
-        else{
+            file.write_all(res.as_bytes())
+                .expect("writing to output file failed");
+        } else {
             let template_url = "https://api.shahin.dev/chord";
-            
-            let mut res = ureq::post(template_url)
-            .auth(&self.user.to_string(),&self.key.to_string())
-            .send_json(json!({
-                "colors":self.colors,
-                "opacity":self.opacity,
-                "matrix":self.matrix,
-                "names":self.names,
-                "padding":self.padding,
-                "width":self.width,
-                "label_color":self.label_color,
-                "wrap_labels":self.wrap_labels,
-                "credit":self.credit,
-                "margin":self.margin,
-                "font_size":self.font_size,
-                "font_size_large":self.font_size_large,
-                "details":self.details,
-                "details_thumbs":self.details_thumbs,
-                "thumbs_font_size":self.thumbs_font_size,
-                "thumbs_width":self.thumbs_width,
-                "thumbs_margin":self.thumbs_margin,
-                "popup_width":self.popup_width,
-                "noun":self.noun,
-                "details_separator":self.details_separator,
-                "divide":self.divide,
-                "divide_idx":self.divide_idx,
-                "divide_size":self.divide_size,
-                "instances":self.instances
-            }))
-            .into_string().unwrap();
+
+            let res = ureq::post(template_url)
+                .auth(&self.user.to_string(), &self.key.to_string())
+                .send_json(json!({
+                    "colors":self.colors,
+                    "opacity":self.opacity,
+                    "matrix":self.matrix,
+                    "names":self.names,
+                    "padding":self.padding,
+                    "width":self.width,
+                    "label_color":self.label_color,
+                    "wrap_labels":self.wrap_labels,
+                    "credit":self.credit,
+                    "margin":self.margin,
+                    "font_size":self.font_size,
+                    "font_size_large":self.font_size_large,
+                    "details":self.details,
+                    "details_thumbs":self.details_thumbs,
+                    "thumbs_font_size":self.thumbs_font_size,
+                    "thumbs_width":self.thumbs_width,
+                    "thumbs_margin":self.thumbs_margin,
+                    "popup_width":self.popup_width,
+                    "noun":self.noun,
+                    "details_separator":self.details_separator,
+                    "divide":self.divide,
+                    "divide_idx":self.divide_idx,
+                    "divide_size":self.divide_size,
+                    "instances":self.instances
+                }))
+                .into_string()
+                .unwrap();
 
             let file_name = "out.html";
-            
+
             let mut file = fs::File::create(file_name).unwrap();
-            file.write_all(res.as_bytes());
+            file.write_all(res.as_bytes())
+                .expect("writing to output file failed");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,37 @@
 mod lib;
-use lib::{Chord, Plot};
-use std::fs;
-use std::io::prelude::*;
-use nanoid::nanoid;
+use lib::Plot;
 
 fn main() {
     let matrix: Vec<Vec<f64>> = vec![
-    vec![0.0, 0.0, 0.0, 1.0, 4.0, 1.0],
-    vec![0.0, 0.0, 0.0, 1.0, 3.0, 2.0],
-    vec![0.0, 0.0, 0.0, 1.0, 2.0, 2.0],
-    vec![1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
-    vec![4.0, 3.0, 2.0, 0.0, 0.0, 0.0],
-    vec![1.0, 2.0, 2.0, 0.0, 0.0, 0.0],
+        vec![0.0, 0.0, 0.0, 1.0, 4.0, 1.0],
+        vec![0.0, 0.0, 0.0, 1.0, 3.0, 2.0],
+        vec![0.0, 0.0, 0.0, 1.0, 2.0, 2.0],
+        vec![1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+        vec![4.0, 3.0, 2.0, 0.0, 0.0, 0.0],
+        vec![1.0, 2.0, 2.0, 0.0, 0.0, 0.0],
     ];
 
     let names: Vec<String> = vec!["A", "B", "C", "1", "2", "3"]
-    .into_iter()
-    .map(String::from)
-    .collect();
+        .into_iter()
+        .map(String::from)
+        .collect();
 
-    let colors: Vec<String> = vec!["#7400B8", "#5E60CE", "#5684D6", "#56CFE1", "#64DFDF", "#80FFDB"]
+    let colors: Vec<String> = vec![
+        "#7400B8", "#5E60CE", "#5684D6", "#56CFE1", "#64DFDF", "#80FFDB",
+    ]
     .into_iter()
     .map(String::from)
     .collect();
-    
 
     lib::Chord {
-      user: String::from("hello@shahinrostami.com"),
+        user: String::from("hello@shahinrostami.com"),
         key: String::from("CP-2233d274-f968-4018-870b-4926b1793912"),
         matrix: matrix.clone(),
         names: names.clone(),
-       colors: colors,
+        colors,
         divide: true,
         divide_idx: 3,
         ..lib::Chord::default()
     }
     .to_html();
-
 }

--- a/src/rich_hover.rs
+++ b/src/rich_hover.rs
@@ -1,6 +1,5 @@
 mod lib;
 use lib::{Chord, Plot};
-use nanoid::nanoid;
 use std::fs;
 use std::io::prelude::*;
 

--- a/src/rich_hover.rs
+++ b/src/rich_hover.rs
@@ -1,35 +1,216 @@
 mod lib;
 use lib::{Chord, Plot};
+use nanoid::nanoid;
 use std::fs;
 use std::io::prelude::*;
-use nanoid::nanoid;
 
 fn main() {
     let matrix: Vec<Vec<f64>> = vec![
-    vec![0., 5., 6., 4., 7., 4.],
-    vec![5., 0., 5., 4., 6., 5.],
-    vec![6., 5., 0., 4., 5., 5.],
-    vec![4., 4., 4., 0., 5., 5.],
-    vec![7., 6., 5., 5., 0., 4.],
-    vec![4., 5., 5., 5., 4., 0.],
+        vec![0., 5., 6., 4., 7., 4.],
+        vec![5., 0., 5., 4., 6., 5.],
+        vec![6., 5., 0., 4., 5., 5.],
+        vec![4., 4., 4., 0., 5., 5.],
+        vec![7., 6., 5., 5., 0., 4.],
+        vec![4., 5., 5., 5., 4., 0.],
     ];
 
-    let details : Vec<Vec<Vec<String>>> = vec![
-        vec![vec![], vec!["Movie 1".to_string(),"Movie 2".to_string()], vec!["Movie 3".to_string(),"Movie 4".to_string(),"Movie 5".to_string()], vec!["Movie 6".to_string(),"Movie 7".to_string()], vec!["Movie 8".to_string(),"Movie 9".to_string(),"Movie 10".to_string(),"Movie 11".to_string()], vec!["Movie 12".to_string()]],
-        vec![vec!["Movie 13".to_string(),"Movie 14".to_string()], vec![], vec!["Movie 15".to_string(),"Movie 16".to_string()], vec!["Movie 17".to_string()], vec!["Movie 18".to_string(),"Movie 19".to_string(),"Movie 20".to_string()], vec!["Movie 21".to_string(),"Movie 22".to_string()]],
-        vec![vec!["Movie 23".to_string(),"Movie 24".to_string(),"Movie 25".to_string()], vec!["Movie 26".to_string(),"Movie 27".to_string()], vec![], vec!["Movie 28".to_string()], vec!["Movie 29".to_string(),"Movie 30".to_string()], vec!["Movie 31".to_string(),"Movie 32".to_string()]],
-        vec![vec!["Movie 33".to_string()], vec!["Movie 34".to_string()], vec!["Movie 35".to_string()], vec![], vec!["Movie 36".to_string(),"Movie 37".to_string()], vec!["Movie 38".to_string(),"Movie 39".to_string()]],
-        vec![vec!["Movie 40".to_string(),"Movie 41".to_string(),"Movie 42".to_string(),"Movie 43".to_string()], vec!["Movie 44".to_string(),"Movie 45".to_string(),"Movie 46".to_string()], vec!["Movie 47".to_string(),"Movie 48".to_string()], vec!["Movie 49".to_string(),"Movie 50".to_string()], vec![], vec!["Movie 51".to_string()]],
-        vec![vec!["Movie 52".to_string()], vec!["Movie 53".to_string(),"Movie 54".to_string()], vec!["Movie 55".to_string(),"Movie 56".to_string()], vec!["Movie 57".to_string(),"Movie 58".to_string()], vec!["Movie 59".to_string()], vec![]]
+    let details: Vec<Vec<Vec<String>>> = vec![
+        vec![
+            vec![],
+            vec!["Movie 1".to_string(), "Movie 2".to_string()],
+            vec![
+                "Movie 3".to_string(),
+                "Movie 4".to_string(),
+                "Movie 5".to_string(),
+            ],
+            vec!["Movie 6".to_string(), "Movie 7".to_string()],
+            vec![
+                "Movie 8".to_string(),
+                "Movie 9".to_string(),
+                "Movie 10".to_string(),
+                "Movie 11".to_string(),
+            ],
+            vec!["Movie 12".to_string()],
+        ],
+        vec![
+            vec!["Movie 13".to_string(), "Movie 14".to_string()],
+            vec![],
+            vec!["Movie 15".to_string(), "Movie 16".to_string()],
+            vec!["Movie 17".to_string()],
+            vec![
+                "Movie 18".to_string(),
+                "Movie 19".to_string(),
+                "Movie 20".to_string(),
+            ],
+            vec!["Movie 21".to_string(), "Movie 22".to_string()],
+        ],
+        vec![
+            vec![
+                "Movie 23".to_string(),
+                "Movie 24".to_string(),
+                "Movie 25".to_string(),
+            ],
+            vec!["Movie 26".to_string(), "Movie 27".to_string()],
+            vec![],
+            vec!["Movie 28".to_string()],
+            vec!["Movie 29".to_string(), "Movie 30".to_string()],
+            vec!["Movie 31".to_string(), "Movie 32".to_string()],
+        ],
+        vec![
+            vec!["Movie 33".to_string()],
+            vec!["Movie 34".to_string()],
+            vec!["Movie 35".to_string()],
+            vec![],
+            vec!["Movie 36".to_string(), "Movie 37".to_string()],
+            vec!["Movie 38".to_string(), "Movie 39".to_string()],
+        ],
+        vec![
+            vec![
+                "Movie 40".to_string(),
+                "Movie 41".to_string(),
+                "Movie 42".to_string(),
+                "Movie 43".to_string(),
+            ],
+            vec![
+                "Movie 44".to_string(),
+                "Movie 45".to_string(),
+                "Movie 46".to_string(),
+            ],
+            vec!["Movie 47".to_string(), "Movie 48".to_string()],
+            vec!["Movie 49".to_string(), "Movie 50".to_string()],
+            vec![],
+            vec!["Movie 51".to_string()],
+        ],
+        vec![
+            vec!["Movie 52".to_string()],
+            vec!["Movie 53".to_string(), "Movie 54".to_string()],
+            vec!["Movie 55".to_string(), "Movie 56".to_string()],
+            vec!["Movie 57".to_string(), "Movie 58".to_string()],
+            vec!["Movie 59".to_string()],
+            vec![],
+        ],
     ];
 
-    let details_thumbs : Vec<Vec<Vec<String>>> = vec![
-        vec![vec![], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()]],
-        vec![vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec![], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()]],
-        vec![vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec![], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()]],
-        vec![vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec![], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()]],
-        vec![vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec![], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()]],
-        vec![vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),"https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()], vec![]],
+    let details_thumbs: Vec<Vec<Vec<String>>> = vec![
+        vec![
+            vec![],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+        ],
+        vec![
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+        ],
+        vec![
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![],
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+        ],
+        vec![
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+            vec![],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+        ],
+        vec![
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![],
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+        ],
+        vec![
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec![
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+                "https://shahinrostami.com/images/stami-labs/lablet.png".to_string(),
+            ],
+            vec!["https://shahinrostami.com/images/stami-labs/lablet.png".to_string()],
+            vec![],
+        ],
     ];
 
     let names: Vec<String> = vec![


### PR DESCRIPTION
Fixes #4 

This PR is split into two commits:

- the first commit fixes a bunch of existing warnings/formatting inconsistencies, in line with the standard `rustfmt` and `clippy` toolchain. This commit is optional and doesn't affect the functionality of the crate, it just pulls out a bunch of stuff my editor applied automatically for clarity
- the second commit updates the crate to always use server side rendering. This includes:
  - factoring out the shared functionality to new `template_url` and `render` methods
  - removing the unused dependency `nanoid`

This is a cool project, thanks for supporting Rust directly!