### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Dr. Shahin Rostami <hello@shahinrostami.com>"]
 description = "Engaging visualisations, made easy."
 homepage = "https://plotapi.com"
-repository = "http://github.com/shahinrostami/plotapi_rs"
+repository = "https://github.com/shahinrostami/plotapi_rs"
 license = "MIT"
 keywords = ["plot", "chart", "visualization"]
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97